### PR TITLE
Add GET parameter to url when requesting softpage

### DIFF
--- a/softpage.js
+++ b/softpage.js
@@ -59,8 +59,11 @@ class SoftPage {
         }
         // otherwise, do it the regular way
         else {
+            // Append softpage=True to the request URL in case the responding page behaves differently for softpages.
+            let sofpageIdentificationUrlParameter = href.indexOf('?') === -1 ? '?softpage=true' : '&softpage=true';
+            let softpageUrl = href + sofpageIdentificationUrlParameter;
             request
-                .get(href)
+                .get(softpageUrl)
                 .set('X-Requested-With', 'XMLHttpRequest')
                 .end((error, result) => {
                     this.modal.open();


### PR DESCRIPTION
We've got django views returning different HTML responses depending on whether it's a softpage or not (eg. slimmed down markup, remove header/footer, don't link to css files etc).

So it behaves like this:
- `GET /sample-page` -> normal template is returned
- `AJAX GET /sample-page` -> "slim" page is returned

This prevents full-page HTTP caching to work, since the caching system thinks the requests are the same.

This PR fixes this, by appending a GET parameter `?softpage=true` to the requested URL. This way 1. the view knows it's serving a softpage (which is more explicit than simply checking whether it's an ajax request) and 2. a caching system is able to differentiate between the softpage and a normal request.